### PR TITLE
feat: expose postgres via MetalLB LoadBalancer, remove ingress TCP proxy

### DIFF
--- a/apps/base/postgres/helmrepository.yaml
+++ b/apps/base/postgres/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: bitnami
+  namespace: databases
+spec:
+  interval: 24h
+  url: https://charts.bitnami.com/bitnami

--- a/apps/base/postgres/kustomization.yaml
+++ b/apps/base/postgres/kustomization.yaml
@@ -1,3 +1,6 @@
 resources:
+  - "namespace.yaml"
+  - "helmrepository.yaml"
   - "postgres-auth.yaml"
   - "helmrelease.yaml"
+  - "service-lb.yaml"

--- a/apps/base/postgres/namespace.yaml
+++ b/apps/base/postgres/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: databases

--- a/apps/base/postgres/service-lb.yaml
+++ b/apps/base/postgres/service-lb.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-lb
+  namespace: databases
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.1.244
+  selector:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: postgres
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432

--- a/infrastructure/base/ingress-nginx/helmrelease.yaml
+++ b/infrastructure/base/ingress-nginx/helmrelease.yaml
@@ -16,8 +16,6 @@ spec:
   interval: 10m
   values:
     controller:
-      tcp:
-        "5432": "databases/postgres-primary:5432"
       resources:
         requests:
           cpu: 200m

--- a/infrastructure/base/ingress-nginx/kustomization.yaml
+++ b/infrastructure/base/ingress-nginx/kustomization.yaml
@@ -4,4 +4,3 @@
 resources:
   - "helmrepository.yaml"
   - "helmrelease.yaml"
-  - "tcp-services-configmap.yaml"

--- a/infrastructure/base/ingress-nginx/tcp-services-configmap.yaml
+++ b/infrastructure/base/ingress-nginx/tcp-services-configmap.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: tcp-services
-  namespace: homelab
-data:
-  "5432": "databases/postgres-primary:5432"


### PR DESCRIPTION
- Add dedicated LoadBalancer Service for PostgreSQL (192.168.1.244)
- Remove TCP ConfigMap and helmrelease tcp config from ingress-nginx
- Add DNS in Pi-hole: postgres.home.lab -> 192.168.1.244